### PR TITLE
Consider infinitive verbs equivalent

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -263,6 +263,7 @@ describe('Real-world usage', () => {
       .doesntMatter(Equivalency.en.COMMON_PUNCTUATION)
       .doesntMatter(Equivalency.en.COMMON_SYMBOLS)
       .doesntMatter(Equivalency.ACCENTS)
+      .doesntMatter(Equivalency.en.INFINITIVE_VERBS)
       .matters('-');
 
     it('should mark candidates equivalent that we want to count as equivalent', () => {
@@ -295,6 +296,27 @@ describe('Real-world usage', () => {
           theCorrectAnswer
         );
         expect(isEquivalent).toBe(false);
+      });
+    });
+
+    it('should mark infinitive verbs as equivalent', () => {
+      const theCorrectAnswer = 'write';
+
+      const candidates = [
+        'to write',
+        '  to   write',
+        ' TO write',
+        'TO   write',
+        ' tO writE',
+      ];
+
+      candidates.forEach(candidate => {
+        const { isEquivalent } = enEquivalency.equivalent(
+          candidate,
+          theCorrectAnswer
+        );
+
+        expect(isEquivalent).toBe(true);
       });
     });
   });

--- a/lib/en.js
+++ b/lib/en.js
@@ -32,10 +32,23 @@ const COMMON_DIACRITICS = new FunctionRule((s1, s2) => {
   return [normalize(s1prime, 'NFC'), normalize(s2prime, 'NFC')];
 });
 
+const INFINITIVE_VERBS = new FunctionRule((s1, s2) => {
+  let s1prime = normalize(s1, 'NFD');
+  let s2prime = normalize(s2, 'NFD');
+
+  const RE_BEGINS_WITH_TO = /^[\s]*(to)[\s]*/i;
+
+  return [
+    s1prime.replace(RE_BEGINS_WITH_TO, ''),
+    s2prime.replace(RE_BEGINS_WITH_TO, ''),
+  ];
+});
+
 module.exports = {
   ASCII_PUNCTUATION,
   ASCII_SYMBOLS,
   COMMON_PUNCTUATION,
   COMMON_SYMBOLS,
   COMMON_DIACRITICS,
+  INFINITIVE_VERBS
 };


### PR DESCRIPTION
### What/why

https://www.pivotaltracker.com/story/show/160852854

Add an `en` rule to consider infinitive verbs equivalent to just the verb.

### How to test

`npm run test` should do it

cc @spanishdict/engineering-sd-engage 