### PR TITLE
Feature 165723543 edit distance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const { Rule, assert } = require('./lib');
+const dl = require('damerau-levenshtein');
 
 class Equivalency {
   constructor() {
@@ -18,7 +19,7 @@ class Equivalency {
     return this;
   }
 
-  equivalent(s1, s2) {
+  equivalent(s1, s2, options = null) {
     let s1prime = s1,
       s2prime = s2;
 
@@ -86,7 +87,17 @@ class Equivalency {
     });
 
     let isEquivalent = s1prime === s2prime;
-    return { isEquivalent: isEquivalent };
+
+    let results = { isEquivalent: isEquivalent };
+
+    if (options && options.calculateEditDistance) {
+      const editDistance = dl(s1prime, s2prime);
+      results = { ...results, editDistance: editDistance.steps };
+    }
+    // console.log('HERE!', s1, '|', s1prime);
+    // console.log('HERE!', s2, '|', s2prime);
+
+    return results;
   }
 
   rules() {

--- a/index.js
+++ b/index.js
@@ -92,9 +92,7 @@ class Equivalency {
 
     if (options && options.calculateEditDistance) {
       const editDistance = dl(s1prime, s2prime);
-      results = Object.assign({}, results, {
-        editDistance: editDistance.steps,
-      });
+      results.editDistance = editDistance.steps;
     }
 
     return results;

--- a/index.js
+++ b/index.js
@@ -94,8 +94,6 @@ class Equivalency {
       const editDistance = dl(s1prime, s2prime);
       results = { ...results, editDistance: editDistance.steps };
     }
-    // console.log('HERE!', s1, '|', s1prime);
-    // console.log('HERE!', s2, '|', s2prime);
 
     return results;
   }

--- a/index.js
+++ b/index.js
@@ -92,7 +92,9 @@ class Equivalency {
 
     if (options && options.calculateEditDistance) {
       const editDistance = dl(s1prime, s2prime);
-      results = { ...results, editDistance: editDistance.steps };
+      results = Object.assign({}, results, {
+        editDistance: editDistance.steps,
+      });
     }
 
     return results;

--- a/index.test.js
+++ b/index.test.js
@@ -439,7 +439,7 @@ describe('Real-world usage', () => {
           ['e l c ombinado', 'el combinado'],
           ['el cobminado', 'el combinado'],
           ['el comdinabo', 'el combinado'],
-          ['apple', 'apples'],
+          ['manzana', 'manzanas'],
         ];
         const editDistances = [1, 1, 2, 1, 2, 1];
         const options = { calculateEditDistance: true };

--- a/index.test.js
+++ b/index.test.js
@@ -271,139 +271,141 @@ describe('Equivalency', () => {
 });
 
 describe('Real-world usage', () => {
-  describe('es equivalency', () => {
-    const esEquivalency = new Equivalency()
-      .doesntMatter(Equivalency.UNICODE_NORMALIZATION)
-      .doesntMatter(Equivalency.WHITESPACE_DIFFERENCES)
-      .doesntMatter(Equivalency.CAPITALIZATION)
-      .doesntMatter(Equivalency.es.COMMON_PUNCTUATION)
-      .doesntMatter(Equivalency.es.COMMON_SYMBOLS)
-      .matters('-');
+  describe('isEquivalent', () => {
+    describe('es', () => {
+      const esEquivalency = new Equivalency()
+        .doesntMatter(Equivalency.UNICODE_NORMALIZATION)
+        .doesntMatter(Equivalency.WHITESPACE_DIFFERENCES)
+        .doesntMatter(Equivalency.CAPITALIZATION)
+        .doesntMatter(Equivalency.es.COMMON_PUNCTUATION)
+        .doesntMatter(Equivalency.es.COMMON_SYMBOLS)
+        .matters('-');
 
-    it('should mark candidates equivalent that we want to count as equivalent', () => {
-      const theCorrectAnswer = '¿Cómo se dice...?';
-
-      const candidates = [
-        '¿Cómo se dice...?',
-        'Cómo se dice',
-        'C..,.,.??.,.ómo s.......?!?!?!??e dice.....???????????¿¿¿¿¿¿',
-      ];
-
-      candidates.forEach(candidate => {
-        const { isEquivalent } = esEquivalency.equivalent(
-          candidate,
-          theCorrectAnswer
-        );
-        expect(isEquivalent).toBe(true);
-      });
-    });
-
-    it('should mark candidates inequivalent that we dont want to count as equivalent', () => {
-      const theCorrectAnswer = '¿Cómo se dice...?';
-
-      const candidates = ['¿Como se dice...?', 'Cómosedice'];
-
-      candidates.forEach(candidate => {
-        const { isEquivalent } = esEquivalency.equivalent(
-          candidate,
-          theCorrectAnswer
-        );
-        expect(isEquivalent).toBe(false);
-      });
-    });
-  });
-
-  describe('en equivalency', () => {
-    const enEquivalency = new Equivalency()
-      .doesntMatter(Equivalency.UNICODE_NORMALIZATION)
-      .doesntMatter(Equivalency.WHITESPACE_DIFFERENCES)
-      .doesntMatter(Equivalency.CAPITALIZATION)
-      .doesntMatter(Equivalency.en.COMMON_PUNCTUATION)
-      .doesntMatter(Equivalency.en.COMMON_SYMBOLS)
-      .doesntMatter(Equivalency.COMMON_DIACRITICS)
-      .matters('-');
-
-    it('should mark candidates equivalent that we want to count as equivalent', () => {
-      const theCorrectAnswer = 'How are you today?';
-
-      const candidates = [
-        'how are you, today?',
-        'HOW ARE YOU  TODAY',
-        'how aré you today',
-        '  how aré you today  ',
-      ];
-
-      candidates.forEach(candidate => {
-        const { isEquivalent } = enEquivalency.equivalent(
-          candidate,
-          theCorrectAnswer
-        );
-        expect(isEquivalent).toBe(true);
-      });
-    });
-
-    it('should mark candidates inequivalent that we dont want to count as equivalent', () => {
-      const theCorrectAnswer = 'How are you today?';
-
-      const candidates = ['how are you, to-day?'];
-
-      candidates.forEach(candidate => {
-        const { isEquivalent } = enEquivalency.equivalent(
-          candidate,
-          theCorrectAnswer
-        );
-        expect(isEquivalent).toBe(false);
-      });
-    });
-
-    describe('INFINITIVE_VERBS', () => {
-      let equivalency = null;
-
-      beforeEach(() => {
-        equivalency = new Equivalency().doesntMatter(
-          Equivalency.en.INFINITIVE_VERBS
-        );
-      });
-
-      it('should mark infinitive verbs as equivalent', () => {
-        const theCorrectAnswer = 'write';
+      it('should mark candidates equivalent that we want to count as equivalent', () => {
+        const theCorrectAnswer = '¿Cómo se dice...?';
 
         const candidates = [
-          'to write',
-          '  to   write',
-          ' TO write',
-          'TO   write',
-          ' tO write',
+          '¿Cómo se dice...?',
+          'Cómo se dice',
+          'C..,.,.??.,.ómo s.......?!?!?!??e dice.....???????????¿¿¿¿¿¿',
         ];
 
         candidates.forEach(candidate => {
+          const { isEquivalent } = esEquivalency.equivalent(
+            candidate,
+            theCorrectAnswer
+          );
+          expect(isEquivalent).toBe(true);
+        });
+      });
+
+      it('should mark candidates inequivalent that we dont want to count as equivalent', () => {
+        const theCorrectAnswer = '¿Cómo se dice...?';
+
+        const candidates = ['¿Como se dice...?', 'Cómosedice'];
+
+        candidates.forEach(candidate => {
+          const { isEquivalent } = esEquivalency.equivalent(
+            candidate,
+            theCorrectAnswer
+          );
+          expect(isEquivalent).toBe(false);
+        });
+      });
+    });
+
+    describe('en', () => {
+      const enEquivalency = new Equivalency()
+        .doesntMatter(Equivalency.UNICODE_NORMALIZATION)
+        .doesntMatter(Equivalency.WHITESPACE_DIFFERENCES)
+        .doesntMatter(Equivalency.CAPITALIZATION)
+        .doesntMatter(Equivalency.en.COMMON_PUNCTUATION)
+        .doesntMatter(Equivalency.en.COMMON_SYMBOLS)
+        .doesntMatter(Equivalency.COMMON_DIACRITICS)
+        .matters('-');
+
+      it('should mark candidates equivalent that we want to count as equivalent', () => {
+        const theCorrectAnswer = 'How are you today?';
+
+        const candidates = [
+          'how are you, today?',
+          'HOW ARE YOU  TODAY',
+          'how aré you today',
+          '  how aré you today  ',
+        ];
+
+        candidates.forEach(candidate => {
+          const { isEquivalent } = enEquivalency.equivalent(
+            candidate,
+            theCorrectAnswer
+          );
+          expect(isEquivalent).toBe(true);
+        });
+      });
+
+      it('should mark candidates inequivalent that we dont want to count as equivalent', () => {
+        const theCorrectAnswer = 'How are you today?';
+
+        const candidates = ['how are you, to-day?'];
+
+        candidates.forEach(candidate => {
+          const { isEquivalent } = enEquivalency.equivalent(
+            candidate,
+            theCorrectAnswer
+          );
+          expect(isEquivalent).toBe(false);
+        });
+      });
+
+      describe('INFINITIVE_VERBS', () => {
+        let equivalency = null;
+
+        beforeEach(() => {
+          equivalency = new Equivalency().doesntMatter(
+            Equivalency.en.INFINITIVE_VERBS
+          );
+        });
+
+        it('should mark infinitive verbs as equivalent', () => {
+          const theCorrectAnswer = 'write';
+
+          const candidates = [
+            'to write',
+            '  to   write',
+            ' TO write',
+            'TO   write',
+            ' tO write',
+          ];
+
+          candidates.forEach(candidate => {
+            const { isEquivalent } = equivalency.equivalent(
+              candidate,
+              theCorrectAnswer
+            );
+
+            expect(isEquivalent).toBe(true);
+          });
+        });
+
+        it('should require a space after to in front of verbs', () => {
+          const theCorrectAnswer = 'write';
+
+          const candidate = 'towrite';
+
           const { isEquivalent } = equivalency.equivalent(
             candidate,
             theCorrectAnswer
           );
 
-          expect(isEquivalent).toBe(true);
+          expect(isEquivalent).toBe(false);
         });
-      });
-
-      it('should require a space after to in front of verbs', () => {
-        const theCorrectAnswer = 'write';
-
-        const candidate = 'towrite';
-
-        const { isEquivalent } = equivalency.equivalent(
-          candidate,
-          theCorrectAnswer
-        );
-
-        expect(isEquivalent).toBe(false);
       });
     });
   });
 
-  describe('edit distance (diacritics agnostic)', () => {
+  describe('editDistance (diacritics agnostic)', () => {
     describe('es', () => {
-      const esEquivalency = new Equivalency()
+      const agnosticEsEquivalency = new Equivalency()
         .doesntMatter(Equivalency.UNICODE_NORMALIZATION)
         .doesntMatter(Equivalency.WHITESPACE_DIFFERENCES)
         .doesntMatter(Equivalency.CAPITALIZATION)
@@ -421,7 +423,11 @@ describe('Real-world usage', () => {
         ];
         const options = { calculateEditDistance: true };
         inputs.forEach(([s1, s2]) => {
-          const { editDistance } = esEquivalency.equivalent(s1, s2, options);
+          const { editDistance } = agnosticEsEquivalency.equivalent(
+            s1,
+            s2,
+            options
+          );
           expect(editDistance).toEqual(0);
         });
       });
@@ -438,7 +444,11 @@ describe('Real-world usage', () => {
         const editDistances = [1, 1, 2, 1, 2, 1];
         const options = { calculateEditDistance: true };
         inputs.forEach(([s1, s2], index) => {
-          const { editDistance } = esEquivalency.equivalent(s1, s2, options);
+          const { editDistance } = agnosticEsEquivalency.equivalent(
+            s1,
+            s2,
+            options
+          );
           expect(editDistance).toEqual(editDistances[index]);
         });
       });

--- a/index.test.js
+++ b/index.test.js
@@ -30,207 +30,241 @@ describe('Equivalency', () => {
     });
   });
 
-  describe('equivalent (default rules)', () => {
-    it('should return false when inputs are not byte-equal', () => {
+  describe('isEquivalent', () => {
+    describe('equivalent (default rules)', () => {
+      it('should return false when inputs are not byte-equal', () => {
+        const instance = new Equivalency();
+        const inputs = [['a', 'b']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
+        });
+      });
+
+      it('should return true when inputs are byte-equal', () => {
+        const instance = new Equivalency();
+        const inputs = [['a', 'a'], ['💩', '\u{1F4A9}']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
+        });
+      });
+
+      it('adding then removing the same rule should be the same as default rules ', () => {
+        const instance = new Equivalency()
+          .doesntMatter(Equivalency.en.COMMON_PUNCTUATION)
+          .matters(Equivalency.en.COMMON_PUNCTUATION);
+        const inputs = [['what he did.', 'what he did?']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
+        });
+      });
+    });
+
+    describe('equivalent (builtin doesnt matter)', () => {
+      it("should return true when inputs differ solely by characters that don't matter", () => {
+        const instance = new Equivalency().doesntMatter(
+          Equivalency.en.COMMON_PUNCTUATION
+        );
+        const inputs = [
+          ['what, you did', 'what you did'],
+          ['fire-fly light', 'firefly light'],
+        ];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
+        });
+      });
+
+      it('should return false when inputs differ by characters that do matter', () => {
+        const instance = new Equivalency().doesntMatter(
+          Equivalency.en.COMMON_PUNCTUATION
+        );
+        const inputs = [['what he did', 'what you did']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
+        });
+      });
+    });
+
+    describe('equivalent (chain doesnMatter + matter)', () => {
+      it("should return true when inputs differ solely by characters that don't matter", () => {
+        const instance = new Equivalency()
+          .doesntMatter(Equivalency.en.COMMON_PUNCTUATION)
+          .matters('-');
+        const inputs = [['what, you did', 'what you did']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
+        });
+      });
+
+      it('should return false when inputs differ by characters that do matter', () => {
+        const instance = new Equivalency()
+          .doesntMatter(Equivalency.en.COMMON_PUNCTUATION)
+          .matters('-');
+        const inputs = [['fire-fly light', 'firefly light']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
+        });
+      });
+    });
+
+    describe('equivalent (capitalization doesnt matter)', () => {
+      it('should return true when inputs differ solely by capitalization', () => {
+        const instance = new Equivalency().doesntMatter(
+          Equivalency.CAPITALIZATION
+        );
+        const inputs = [['us', 'US']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
+        });
+      });
+
+      it('should return false when inputs differ other than by capitalization', () => {
+        const instance = new Equivalency().doesntMatter(
+          Equivalency.CAPITALIZATION
+        );
+        const inputs = [['us', 'usa']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
+        });
+      });
+    });
+
+    describe('equivalent (whitespace doesnt matter)', () => {
+      it('should return true when inputs differ solely by shape of whitespaces', () => {
+        const instance = new Equivalency().doesntMatter(
+          Equivalency.WHITESPACE_DIFFERENCES
+        );
+        const inputs = [['the us of a', 'the	us   of\u2028\u2029a']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
+        });
+      });
+
+      it('should return false when inputs differ other than by shape of whitespaces', () => {
+        const instance = new Equivalency().doesntMatter(
+          Equivalency.WHITESPACE_DIFFERENCES
+        );
+        const inputs = [['the us of a', 'The	us   of\u2028\u2029a']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
+        });
+      });
+    });
+
+    describe('equivalent (common diacritics)', () => {
+      it('should return true when inputs differ solely by common diacritics', () => {
+        const instance = new Equivalency().doesntMatter(
+          Equivalency.COMMON_DIACRITICS
+        );
+        const inputs = [['â', 'a']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
+        });
+      });
+
+      it('should return false when inputs differ other than by common diacritics', () => {
+        const instance = new Equivalency().doesntMatter(
+          Equivalency.COMMON_DIACRITICS
+        );
+        const inputs = [['âb', 'âc']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
+        });
+      });
+
+      it('should return true for more complex inputs', () => {
+        const enEquivalency = new Equivalency()
+          .doesntMatter(Equivalency.UNICODE_NORMALIZATION)
+          .doesntMatter(Equivalency.WHITESPACE_DIFFERENCES)
+          .doesntMatter(Equivalency.CAPITALIZATION)
+          .doesntMatter(Equivalency.en.COMMON_PUNCTUATION)
+          .doesntMatter(Equivalency.en.COMMON_SYMBOLS)
+          .doesntMatter(Equivalency.COMMON_DIACRITICS);
+
+        const { isEquivalent } = enEquivalency.equivalent(
+          'àâäçèéêíïîñóöüÀÂÄÇÈÉÊÍÏÎÑÓÖÜ',
+          'aaaceeeiiinoouAAACEEEIIINOOU'
+        );
+        expect(isEquivalent).toBe(true);
+      });
+    });
+
+    describe('equivalent (unicode normalization doesnt matter)', () => {
+      it('should return true when inputs differ solely by unicode normalization', () => {
+        const instance = new Equivalency().doesntMatter(
+          Equivalency.UNICODE_NORMALIZATION
+        );
+        // composed and decomposed forms of é
+        const inputs = [['\u00e9', '\u0065\u0301']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
+        });
+      });
+
+      it('should return false when inputs differ other than by unicode normalization', () => {
+        const instance = new Equivalency().doesntMatter(
+          Equivalency.UNICODE_NORMALIZATION
+        );
+        // lowercase n \u006e and uppercase N \u004e with combining tilde \u0303
+        const inputs = [['\u006e\u0303', '\u004e\u0303']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
+        });
+      });
+    });
+
+    describe('equivalent (arbitrary word prefix)', () => {
+      it('should be true when rule does not matter', () => {
+        const beginsWithExcuseMe = equivalency.wordPrefix('Excuse me,');
+        const instance = new Equivalency().doesntMatter(beginsWithExcuseMe);
+
+        const inputs = [
+          [
+            'Excuse me, could I borrow some Grey Poupon?',
+            'could I borrow some Grey Poupon?',
+          ],
+          [
+            'Excuse me, could I borrow some Grey Poupon?',
+            'Excuse me, could I borrow some Grey Poupon?',
+          ],
+          ["I'm terribly sorry.", "Excuse me, I'm terribly sorry."],
+          ["I'm terribly sorry.", "Excuse me,      I'm terribly sorry."],
+        ];
+
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
+        });
+      });
+    });
+  });
+
+  describe('editDistance', () => {
+    it('should return an editDistance when calculateEditDistance is true', () => {
       const instance = new Equivalency();
       const inputs = [['a', 'b']];
+      const options = { calculateEditDistance: true };
       inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
+        const { editDistance } = instance.equivalent(s1, s2, options);
+        expect(editDistance).toEqual(1);
       });
     });
 
-    it('should return true when inputs are byte-equal', () => {
+    it('should not return an editDistance when calculateEditDistance is false', () => {
       const instance = new Equivalency();
-      const inputs = [['a', 'a'], ['💩', '\u{1F4A9}']];
+      const inputs = [['a', 'b']];
+      const options = { calculateEditDistance: false };
       inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
+        const { editDistance } = instance.equivalent(s1, s2, options);
+        expect(editDistance).toEqual(undefined);
       });
     });
 
-    it('adding then removing the same rule should be the same as default rules ', () => {
-      const instance = new Equivalency()
-        .doesntMatter(Equivalency.en.COMMON_PUNCTUATION)
-        .matters(Equivalency.en.COMMON_PUNCTUATION);
-      const inputs = [['what he did.', 'what he did?']];
+    it('should not return an editDistance when calculateEditDistance is not provided', () => {
+      const instance = new Equivalency();
+      const inputs = [['a', 'b']];
+      const options = {};
       inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
-      });
-    });
-  });
-
-  describe('equivalent (builtin doesnt matter)', () => {
-    it("should return true when inputs differ solely by characters that don't matter", () => {
-      const instance = new Equivalency().doesntMatter(
-        Equivalency.en.COMMON_PUNCTUATION
-      );
-      const inputs = [
-        ['what, you did', 'what you did'],
-        ['fire-fly light', 'firefly light'],
-      ];
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
-      });
-    });
-
-    it('should return false when inputs differ by characters that do matter', () => {
-      const instance = new Equivalency().doesntMatter(
-        Equivalency.en.COMMON_PUNCTUATION
-      );
-      const inputs = [['what he did', 'what you did']];
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
-      });
-    });
-  });
-
-  describe('equivalent (chain doesnMatter + matter)', () => {
-    it("should return true when inputs differ solely by characters that don't matter", () => {
-      const instance = new Equivalency()
-        .doesntMatter(Equivalency.en.COMMON_PUNCTUATION)
-        .matters('-');
-      const inputs = [['what, you did', 'what you did']];
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
-      });
-    });
-
-    it('should return false when inputs differ by characters that do matter', () => {
-      const instance = new Equivalency()
-        .doesntMatter(Equivalency.en.COMMON_PUNCTUATION)
-        .matters('-');
-      const inputs = [['fire-fly light', 'firefly light']];
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
-      });
-    });
-  });
-
-  describe('equivalent (capitalization doesnt matter)', () => {
-    it('should return true when inputs differ solely by capitalization', () => {
-      const instance = new Equivalency().doesntMatter(
-        Equivalency.CAPITALIZATION
-      );
-      const inputs = [['us', 'US']];
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
-      });
-    });
-
-    it('should return false when inputs differ other than by capitalization', () => {
-      const instance = new Equivalency().doesntMatter(
-        Equivalency.CAPITALIZATION
-      );
-      const inputs = [['us', 'usa']];
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
-      });
-    });
-  });
-
-  describe('equivalent (whitespace doesnt matter)', () => {
-    it('should return true when inputs differ solely by shape of whitespaces', () => {
-      const instance = new Equivalency().doesntMatter(
-        Equivalency.WHITESPACE_DIFFERENCES
-      );
-      const inputs = [['the us of a', 'the	us   of\u2028\u2029a']];
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
-      });
-    });
-
-    it('should return false when inputs differ other than by shape of whitespaces', () => {
-      const instance = new Equivalency().doesntMatter(
-        Equivalency.WHITESPACE_DIFFERENCES
-      );
-      const inputs = [['the us of a', 'The	us   of\u2028\u2029a']];
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
-      });
-    });
-  });
-
-  describe('equivalent (common diacritics)', () => {
-    it('should return true when inputs differ solely by common diacritics', () => {
-      const instance = new Equivalency().doesntMatter(
-        Equivalency.COMMON_DIACRITICS
-      );
-      const inputs = [['â', 'a']];
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
-      });
-    });
-
-    it('should return false when inputs differ other than by common diacritics', () => {
-      const instance = new Equivalency().doesntMatter(
-        Equivalency.COMMON_DIACRITICS
-      );
-      const inputs = [['âb', 'âc']];
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
-      });
-    });
-
-    it('should return true for more complex inputs', () => {
-      const enEquivalency = new Equivalency()
-        .doesntMatter(Equivalency.UNICODE_NORMALIZATION)
-        .doesntMatter(Equivalency.WHITESPACE_DIFFERENCES)
-        .doesntMatter(Equivalency.CAPITALIZATION)
-        .doesntMatter(Equivalency.en.COMMON_PUNCTUATION)
-        .doesntMatter(Equivalency.en.COMMON_SYMBOLS)
-        .doesntMatter(Equivalency.COMMON_DIACRITICS);
-
-      const { isEquivalent } = enEquivalency.equivalent(
-        'àâäçèéêíïîñóöüÀÂÄÇÈÉÊÍÏÎÑÓÖÜ',
-        'aaaceeeiiinoouAAACEEEIIINOOU'
-      );
-      expect(isEquivalent).toBe(true);
-    });
-  });
-
-  describe('equivalent (unicode normalization doesnt matter)', () => {
-    it('should return true when inputs differ solely by unicode normalization', () => {
-      const instance = new Equivalency().doesntMatter(
-        Equivalency.UNICODE_NORMALIZATION
-      );
-      // composed and decomposed forms of é
-      const inputs = [['\u00e9', '\u0065\u0301']];
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
-      });
-    });
-
-    it('should return false when inputs differ other than by unicode normalization', () => {
-      const instance = new Equivalency().doesntMatter(
-        Equivalency.UNICODE_NORMALIZATION
-      );
-      // lowercase n \u006e and uppercase N \u004e with combining tilde \u0303
-      const inputs = [['\u006e\u0303', '\u004e\u0303']];
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: false });
-      });
-    });
-  });
-
-  describe('equivalent (arbitrary word prefix)', () => {
-    it('should be true when rule does not matter', () => {
-      const beginsWithExcuseMe = equivalency.wordPrefix('Excuse me,');
-      const instance = new Equivalency().doesntMatter(beginsWithExcuseMe);
-
-      const inputs = [
-        [
-          'Excuse me, could I borrow some Grey Poupon?',
-          'could I borrow some Grey Poupon?',
-        ],
-        [
-          'Excuse me, could I borrow some Grey Poupon?',
-          'Excuse me, could I borrow some Grey Poupon?',
-        ],
-        ["I'm terribly sorry.", "Excuse me, I'm terribly sorry."],
-        ["I'm terribly sorry.", "Excuse me,      I'm terribly sorry."],
-      ];
-
-      inputs.forEach(([s1, s2]) => {
-        expect(instance.equivalent(s1, s2)).toEqual({ isEquivalent: true });
+        const { editDistance } = instance.equivalent(s1, s2, options);
+        expect(editDistance).toEqual(undefined);
       });
     });
   });
@@ -363,6 +397,102 @@ describe('Real-world usage', () => {
         );
 
         expect(isEquivalent).toBe(false);
+      });
+    });
+  });
+
+  describe('es edit distance (do not care about diacritics', () => {
+    const esEquivalency = new Equivalency()
+      .doesntMatter(Equivalency.UNICODE_NORMALIZATION)
+      .doesntMatter(Equivalency.WHITESPACE_DIFFERENCES)
+      .doesntMatter(Equivalency.CAPITALIZATION)
+      .doesntMatter(Equivalency.es.COMMON_PUNCTUATION)
+      .doesntMatter(Equivalency.es.COMMON_SYMBOLS)
+      .doesntMatter(Equivalency.COMMON_DIACRITICS)
+
+      .matters('-');
+
+    it('should return correct edit distance 1', () => {
+      const inputs = [['como se dice', '¿Cómo se dice?']];
+      const options = { calculateEditDistance: true };
+      inputs.forEach(([s1, s2]) => {
+        const { editDistance } = esEquivalency.equivalent(s1, s2, options);
+        expect(editDistance).toEqual(0);
+      });
+    });
+
+    it('should return correct edit distance 2', () => {
+      const inputs = [['estoy bien y tu', 'estoy bien, ¿y tú?']];
+      const options = { calculateEditDistance: true };
+      inputs.forEach(([s1, s2]) => {
+        const { editDistance } = esEquivalency.equivalent(s1, s2, options);
+        expect(editDistance).toEqual(0);
+      });
+    });
+
+    it('should return correct edit distance 3', () => {
+      const inputs = [['estoy bien y tu', 'estoy bien, ¿y tú?']];
+      const options = { calculateEditDistance: true };
+      inputs.forEach(([s1, s2]) => {
+        const { editDistance } = esEquivalency.equivalent(s1, s2, options);
+        expect(editDistance).toEqual(0);
+      });
+    });
+
+    //   - "e lcombinado" is edit distance 1 from "el combinado" due to swap of significant (single) whitespace and "l"
+    // - "e  l combinado" is edit distance 1 because the two contiguous whitespaces get collapsed into one before computing edistance
+    // - "e l c ombinado" is edit distance 2 due to insertion of 2 extraneous characters (both are whitespace in this instance)
+    // - "el cobminado" is edit distance 1 due to adjacent swap
+    // - "el comdinabo" is not edit distance 1 due to non-adjacent swap
+
+    it('should return correct edit distance cases', () => {
+      const inputs = [
+        ['e lcombinado', 'el combinado'],
+        ['e  l combinado', 'el combinado'],
+        ['e l c ombinado', 'el combinado'],
+        ['el cobminado', 'el combinado'],
+        ['el comdinabo', 'el combinado'],
+      ];
+      const distances = [1, 1, 2, 1, 2];
+      const options = { calculateEditDistance: true };
+      inputs.forEach(([s1, s2], index) => {
+        const { editDistance } = enEquivalency.equivalent(s1, s2, options);
+        expect(editDistance).toEqual(distances[index]);
+      });
+    });
+  });
+
+  describe('en edit distance (do not care about diacritics', () => {
+    const enEquivalency = new Equivalency()
+      .doesntMatter(Equivalency.UNICODE_NORMALIZATION)
+      .doesntMatter(Equivalency.WHITESPACE_DIFFERENCES)
+      .doesntMatter(Equivalency.CAPITALIZATION)
+      .doesntMatter(Equivalency.en.COMMON_PUNCTUATION)
+      .doesntMatter(Equivalency.en.COMMON_SYMBOLS)
+      .doesntMatter(Equivalency.COMMON_DIACRITICS)
+      .matters('-');
+
+    it.only('should return correct edit distance 1', () => {
+      const inputs = [
+        ['more hardworking than', 'more hard-working than'],
+        ['- more hard working than', 'more hard-working than'], // this differs from epic
+        ['mre hard-wrking than', 'more hard-working than'],
+      ];
+      const distances = [1, 3, 2];
+      const options = { calculateEditDistance: true };
+      inputs.forEach(([s1, s2], index) => {
+        const { editDistance } = enEquivalency.equivalent(s1, s2, options);
+        expect(editDistance).toEqual(distances[index]);
+      });
+    });
+
+    it('should return correct edit distance 2', () => {
+      const inputs = [['Im well and you', "I'm well, and you?"]];
+      const distances = [0];
+      const options = { calculateEditDistance: true };
+      inputs.forEach(([s1, s2], index) => {
+        const { editDistance } = enEquivalency.equivalent(s1, s2, options);
+        expect(editDistance).toEqual(distances[index]);
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "ISC",
   "private": false,
   "dependencies": {
+    "damerau-levenshtein": "^1.0.4",
     "is-string": "1.0.4",
     "lodash.get": "4.4.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,6 +2022,11 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
+damerau-levenshtein@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
+  integrity sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"


### PR DESCRIPTION
@sandinmyjoints 

TODO:
- [ ] Follow up PR updating Equivalency usage docs

### What

https://www.pivotaltracker.com/story/show/165723543

Add damerau-levenshtein edit distance algorithm to equivalency. 

https://www.npmjs.com/package/damerau-levenshtein

### How to test

- Take a look at the logical structure of the test suite and see if it makes sense
     - `jest --watch`
- Take a look at the test cases and make sure you don't see any discrepancies
     - The tests that I actually made are within the 2 `editDistance` describe blocks

Test cases come from the Epic Doc (https://www.notion.so/curiositymedia/Vocab-Quiz-Accuracy-Leniency-9b722f8e7edf473798ddb2b921e39e68#3edd5ca42765473489a7a389da4f5902), but I added some of my own as well. 

cc @spanishdict/engineering-sd-engage 