### PR TITLE
Feature add clone

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,19 +8,19 @@ const dl = require('damerau-levenshtein');
 
 class Equivalency {
   constructor() {
-    this.rules = [];
+    this._rules = [];
     this.finalMap = null;
   }
 
   doesntMatter(_rule) {
     const rule = Rule.from(_rule);
-    this.rules.push({ rule, type: 0 });
+    this._rules.push({ rule, type: 0 });
     return this;
   }
 
   matters(_rule) {
     const rule = Rule.from(_rule);
-    this.rules.push({ rule, type: 1 });
+    this._rules.push({ rule, type: 1 });
     return this;
   }
 
@@ -49,7 +49,7 @@ class Equivalency {
     this.finalMap = new Map();
     this.ruleFns = new Set();
 
-    this.rules.forEach(({ rule, type }) => {
+    this._rules.forEach(({ rule, type }) => {
       assert(rule instanceof Rule);
       // FIXME: do something more elegant than type 0 means doesnt matter, type
       // 1 means matters.
@@ -119,7 +119,13 @@ class Equivalency {
   }
 
   rules() {
-    return this.rules;
+    return this._rules;
+  }
+
+  clone() {
+    const clone = new Equivalency();
+    clone._rules = this.rules().slice();
+    return clone;
   }
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -3,13 +3,13 @@ const equivalency = require('./index');
 const { Equivalency } = equivalency;
 const { MapRule } = require('./lib');
 
-describe('equivalency instance', () => {
+describe('default instance', () => {
   it('should be an instance of Equivalency', () => {
     expect(equivalency).toBeInstanceOf(Equivalency);
   });
 });
 
-describe('Equivalency', () => {
+describe('Equivalency statics', () => {
   describe('language builtins', () => {
     it('should have en builtins', () => {
       expect(Equivalency.en).toEqual(
@@ -29,7 +29,9 @@ describe('Equivalency', () => {
       );
     });
   });
+});
 
+describe('instance', () => {
   describe('isEquivalent', () => {
     describe('equivalent (default rules)', () => {
       it('should return false when inputs are not byte-equal', () => {

--- a/index.test.js
+++ b/index.test.js
@@ -270,6 +270,33 @@ describe('instance', () => {
       });
     });
   });
+
+  describe('clone', () => {
+    const inputs = [
+      ['what he did.', 'what he did?', [true, false, false]],
+      ['what he did', 'what he did?', [true, false, false]],
+      ['what he did.', 'what he did', [true, false, true]],
+    ];
+    const original = new Equivalency().doesntMatter(
+      Equivalency.en.COMMON_PUNCTUATION
+    );
+    const clone1 = original.clone().matters(Equivalency.en.COMMON_PUNCTUATION);
+    const clone2 = original.clone().matters('?');
+
+    inputs.forEach(
+      ([s1, s2, [originalExpected, clone1Expected, clone2Expected]]) => {
+        expect(original.equivalent(s1, s2)).toEqual({
+          isEquivalent: originalExpected,
+        });
+        expect(clone1.equivalent(s1, s2)).toEqual({
+          isEquivalent: clone1Expected,
+        });
+        expect(clone2.equivalent(s1, s2)).toEqual({
+          isEquivalent: clone2Expected,
+        });
+      }
+    );
+  });
 });
 
 describe('Real-world usage', () => {


### PR DESCRIPTION
@ahaurw01 

This was on my mental roadmap for equivalency. I think it has the potential to simplify our use of equivalency in checkAnswer (and helpers), as new instances do not need to built for rulesets that are supersets of other rulesets (this is currently happening a few times), but rather rulesets can be built off of each other.

This would be a minor version bump.