### PR TITLE
Updating hyphens rule to support bidirectional equivalencies

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -706,7 +706,7 @@ describe('Real-world usage', () => {
         .doesntMatter(Equivalency.COMMON_DIACRITICS)
         .doesntMatter(Equivalency.HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES);
 
-      it('should handle hyphens correctly', () => {
+      it('should handle hyphens correctly (unidirectional)', () => {
         const target = 'over-the-moon cow';
 
         const correct = [
@@ -732,6 +732,17 @@ describe('Real-world usage', () => {
           const { isEquivalent } = enEquivalency.equivalent(target, test);
           expect(isEquivalent).toBe(false);
         });
+      });
+
+      it('should handle hyphens correctly (bidirectional)', () => {
+        const equivalency = new Equivalency().doesntMatter(Equivalency.HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES_BOTH);
+
+        const target = 'brother in law';
+        expect(equivalency.equivalent(target, 'brother-in-law').isEquivalent).toBe(true);
+        expect(equivalency.equivalent(target, 'brother in-law').isEquivalent).toBe(true);
+        expect(equivalency.equivalent(target, 'brotherin-law').isEquivalent).toBe(false);
+        expect(equivalency.equivalent(target, 'brother-in-law-').isEquivalent).toBe(false);
+
       });
 
       it('should mark candidates equivalent that we want to count as equivalent', () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,8 @@ module.exports = {
     rules.COMBINING_DIACRITICS_BLOCK_EXCEPT_ACUTE_AND_UMLAUT,
   HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES:
     rules.HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES,
+  HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES_BOTH:
+    rules.HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES_BOTH,
   wordPrefix: rules.wordPrefix,
   en: require('./rules-en'),
   es: require('./rules-es'),

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -224,7 +224,13 @@ const wordPrefixRuleCreator = word =>
     { name: `wordPrefixRule '${word}'` }
   );
 
-const hyphensOmittedOrReplacedWithSpaces = new FunctionRule(
+// Target and test are equivalent if both strings are equivalent without the hyphens.
+// If the rule is not set to bidirectional, the strings are equivalent if the target
+// string replaced hyphens with spaces is equal to the original test string.
+//
+// In the unidirectional case, "brother-in-law" is equivalent to "brother in law"
+// but "brother in law" is not equivalent to "brother-in-law"
+const hyphensOmittedOrReplacedWithSpaces = (bidirectional = true) => new FunctionRule(
   (target, test) => {
     const re = /\s*-\s*/g;
 
@@ -237,7 +243,9 @@ const hyphensOmittedOrReplacedWithSpaces = new FunctionRule(
 
     // We also want to accept spaces in `test` in place of hyphens in `target`.
     const targetWithSpacesInsteadOfHyphens = target.replace(re, ' ');
-    return [targetWithSpacesInsteadOfHyphens, test];
+    const testWithSpacesInsteadOfHyphens = test.replace(re, ' ');
+
+    return [targetWithSpacesInsteadOfHyphens, bidirectional ? testWithSpacesInsteadOfHyphens: test];
   },
   {
     name: 'hyphens omitted or replaced with spaces',
@@ -259,5 +267,6 @@ module.exports = {
   UMLAUT: umlautRule,
   COMBINING_DIACRITICS_BLOCK_EXCEPT_ACUTE_AND_UMLAUT: combiningDiacriticsBlockExceptAcuteAndUmlautRule,
   wordPrefix: wordPrefixRuleCreator,
-  HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES: hyphensOmittedOrReplacedWithSpaces,
+  HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES: hyphensOmittedOrReplacedWithSpaces(false),
+  HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES_BOTH: hyphensOmittedOrReplacedWithSpaces(),
 };


### PR DESCRIPTION
@vincecampanale 

### What
Update the hyphen function rules such that "brother in law" is equivalent to "brother-in-law" and vice versa.

Right now "brother in law" is not equivalent to "brother-in-law" because the rule only does the replacing of the hyphens with spaces on the target, not the test. This does it on both.

cc: @iraquint @seankarson 