### PR TITLE
Including standalone acute accent in English common punctuation

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -271,6 +271,50 @@ describe('instance', () => {
         );
       });
 
+
+      it('identifies multiple rules that are reasons (punctuation and diacritics)', () => {
+        const instance = new Equivalency()
+          .matters(Equivalency.en.COMMON_PUNCTUATION)
+          .matters(Equivalency.COMMON_DIACRITICS);
+        const correctAnswer = `didn't become`;
+
+        expect(
+          instance.equivalent(correctAnswer, 'didn´t become', {
+            giveReasons: true,
+          })
+        ).toEqual(
+          expect.objectContaining({
+            isEquivalent: false,
+            reasons: [{ name: 'common punctuation' }],
+          })
+        );
+
+        expect(
+          instance.equivalent(correctAnswer, `dídn't become`, {
+            giveReasons: true,
+          })
+        ).toEqual(
+          expect.objectContaining({
+            isEquivalent: false,
+            reasons: [{ name: 'common diacritics' }],
+          })
+        );
+
+        expect(
+          instance.equivalent(correctAnswer, 'dídn´t become', {
+            giveReasons: true,
+          })
+        ).toEqual(
+          expect.objectContaining({
+            isEquivalent: false,
+            reasons: [
+              { name: 'common punctuation' },
+              { name: 'common diacritics' },
+            ],
+          })
+        );
+      });
+
       it('gives empty array of reasons when giveReasons: true and isEquivalent: true', () => {
         const instance = new Equivalency()
           .doesntMatter(Equivalency.UNICODE_NORMALIZATION)

--- a/lib/rules-en.js
+++ b/lib/rules-en.js
@@ -5,7 +5,7 @@ const normalize = require('./normalize');
 
 // These two lists contain all ASCII symbols, where symbol is defined as a
 // printable ASCII character not matching [ 0-9a-zA-z].
-const ASCII_PUNCTUATION_STR = `!"',-.:;?\``;
+const ASCII_PUNCTUATION_STR = `!"',-.:;?\`´`;
 const ASCII_PUNCTUATION = new RemoveRule(ASCII_PUNCTUATION_STR, {
   name: 'ascii punctuation',
 });

--- a/lib/rules-en.js
+++ b/lib/rules-en.js
@@ -5,7 +5,7 @@ const normalize = require('./normalize');
 
 // These two lists contain all ASCII symbols, where symbol is defined as a
 // printable ASCII character not matching [ 0-9a-zA-z].
-const ASCII_PUNCTUATION_STR = `!"',-.:;?\`´`;
+const ASCII_PUNCTUATION_STR = `!"',-.:;?\``;
 const ASCII_PUNCTUATION = new RemoveRule(ASCII_PUNCTUATION_STR, {
   name: 'ascii punctuation',
 });
@@ -14,7 +14,7 @@ const ASCII_SYMBOLS = new RemoveRule(ASCII_SYMBOLS_STR, {
   name: 'ascii symbols',
 });
 
-const COMMON_NONASCII_PUNCTUATION_STR = `…“”‘’`;
+const COMMON_NONASCII_PUNCTUATION_STR = `…“”‘’´`;
 const COMMON_NONASCII_PUNCTUATION = new RemoveRule(
   COMMON_NONASCII_PUNCTUATION_STR,
   {


### PR DESCRIPTION
@seankarson 

### What
Including the acute accent in the English common punctuation as that it is a key on the Spanish keyboard.

I don't believe this should interfere with the COMMON_DIACRITICS rule since the acute accent should be on top of the appropriate character. Added in a test to test the combination of the two together.

cc: @iraquint @spanishdict/engineering-sd-engage 