### PR TITLE
Cache rule list.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,15 +22,18 @@ function Equivalency() {
   // Holds one object per rule, consisting of the rule and whether or not it
   // matters.
   this._ruleList = [];
+  this._ruleListIsDirty = true;
 }
 
 Equivalency.prototype.doesntMatter = function(_rule) {
   this._ruleList.push({ rule: Rule.from(_rule), matters: false });
+  this._ruleListIsDirty = true;
   return this;
 };
 
 Equivalency.prototype.matters = function(_rule) {
   this._ruleList.push({ rule: Rule.from(_rule), matters: true });
+  this._ruleListIsDirty = true;
   return this;
 };
 
@@ -146,10 +149,18 @@ Equivalency.prototype.compare = Equivalency.prototype.equivalent = function(
   if (
     this._ruleList.length === 0 ||
     this._ruleList[this._ruleList.length - 1].rule !== identityRule
-  )
+  ) {
+    this._ruleListIsDirty = true;
     this._ruleList.push({ rule: identityRule, matters: true });
+  }
 
-  const [finalMap, ruleFns] = Equivalency._collapseRules(this._ruleList);
+  let finalMap = this.finalMap,
+    ruleFns = this.ruleFns;
+  if (!finalMap || !ruleFns || this._ruleListIsDirty) {
+    [finalMap, ruleFns] = Equivalency._collapseRules(this._ruleList);
+    this.finalMap = finalMap;
+    this.ruleFns = ruleFns;
+  }
 
   const {
     isEquivalent,

--- a/index.test.js
+++ b/index.test.js
@@ -104,6 +104,31 @@ describe('instance', () => {
         });
       });
 
+      it('should update rule list when it changes (bust cache)', () => {
+        const instance = new Equivalency().matters(
+          Equivalency.en.COMMON_PUNCTUATION
+        );
+        const inputs = [['what he did.', 'what he did?']];
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2, { giveReasons: true })).toEqual(
+            expect.objectContaining({
+              isEquivalent: false,
+              reasons: [{ name: 'common punctuation' }],
+            })
+          );
+        });
+        instance.doesntMatter(Equivalency.en.COMMON_PUNCTUATION);
+        // These fail if this._ruleListIsDirty is not checked.
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2, { giveReasons: true })).toEqual(
+            expect.objectContaining({
+              isEquivalent: true,
+              reasons: [],
+            })
+          );
+        });
+      });
+
       it('doesnt throw when asked to give reasons for 15 matters rules and not explicitly told to do so', () => {
         const instance = new Equivalency()
           .matters('a')
@@ -240,9 +265,7 @@ describe('instance', () => {
         ).toEqual(
           expect.objectContaining({
             isEquivalent: false,
-            reasons: [
-              { name: 'common punctuation and symbols' },
-            ],
+            reasons: [{ name: 'common punctuation and symbols' }],
           })
         );
 
@@ -324,7 +347,6 @@ describe('instance', () => {
           })
         );
       });
-
 
       it('identifies multiple rules that are reasons (punctuation and diacritics)', () => {
         const instance = new Equivalency()
@@ -439,7 +461,10 @@ describe('instance', () => {
           expect.objectContaining({
             isEquivalent: false,
             reasons: [
-              { name: 'combining diacritics block except acute and umlaut and n tilde' },
+              {
+                name:
+                  'combining diacritics block except acute and umlaut and n tilde',
+              },
             ],
           })
         );
@@ -452,7 +477,10 @@ describe('instance', () => {
           expect.objectContaining({
             isEquivalent: false,
             reasons: [
-              { name: 'combining diacritics block except acute and umlaut and n tilde' },
+              {
+                name:
+                  'combining diacritics block except acute and umlaut and n tilde',
+              },
             ],
           })
         );
@@ -477,7 +505,10 @@ describe('instance', () => {
             isEquivalent: false,
             reasons: [
               { name: 'acute accent' },
-              { name: 'combining diacritics block except acute and umlaut and n tilde' },
+              {
+                name:
+                  'combining diacritics block except acute and umlaut and n tilde',
+              },
             ],
           })
         );
@@ -652,10 +683,7 @@ describe('instance', () => {
           .doesntMatter(Equivalency.CAPITALIZATION)
           .doesntMatter(Equivalency.TILDE);
 
-        const { isEquivalent } = enEquivalency.equivalent(
-          'ãÃõÕñÑ',
-          'aaoonn'
-        );
+        const { isEquivalent } = enEquivalency.equivalent('ãÃõÕñÑ', 'aaoonn');
         expect(isEquivalent).toBe(true);
       });
     });
@@ -869,14 +897,23 @@ describe('Real-world usage', () => {
       });
 
       it('should handle hyphens correctly (bidirectional)', () => {
-        const equivalency = new Equivalency().doesntMatter(Equivalency.HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES_BOTH);
+        const equivalency = new Equivalency().doesntMatter(
+          Equivalency.HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES_BOTH
+        );
 
         const target = 'brother in law';
-        expect(equivalency.equivalent(target, 'brother-in-law').isEquivalent).toBe(true);
-        expect(equivalency.equivalent(target, 'brother in-law').isEquivalent).toBe(true);
-        expect(equivalency.equivalent(target, 'brotherin-law').isEquivalent).toBe(false);
-        expect(equivalency.equivalent(target, 'brother-in-law-').isEquivalent).toBe(false);
-
+        expect(
+          equivalency.equivalent(target, 'brother-in-law').isEquivalent
+        ).toBe(true);
+        expect(
+          equivalency.equivalent(target, 'brother in-law').isEquivalent
+        ).toBe(true);
+        expect(
+          equivalency.equivalent(target, 'brotherin-law').isEquivalent
+        ).toBe(false);
+        expect(
+          equivalency.equivalent(target, 'brother-in-law-').isEquivalent
+        ).toBe(false);
       });
 
       it('should mark candidates equivalent that we want to count as equivalent', () => {


### PR DESCRIPTION
When comparing, a lot of time was being spent collapsing rules, which was done on every call to compare, but really only needs to happen when the rule list changes.
<img width="1436" alt="Screen Shot 2021-06-18 at 16 46 43" src="https://user-images.githubusercontent.com/606772/122614595-f5869400-d054-11eb-8cfc-4837afc5ffb0.png">
