### PR TITLE
Mark as not dirty once rules are collapsed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ Equivalency._collapseRules = function(rules) {
     }
     /* eslint-enable indent */
   });
+  this._ruleListIsDirty = false;
   return [collapsedMap, ruleFns];
 };
 


### PR DESCRIPTION
Missed this in https://github.com/spanishdict/equivalency/pull/31.