### PR TITLE
Feature: [#179454867] supoort slashes in the word prefix rule

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/index.test.js
+++ b/index.test.js
@@ -740,6 +740,19 @@ describe('instance', () => {
           );
         });
       });
+
+      it('should be true when rule does not matter and the word contains slashes', () => {
+        const beginsWithExcuseMe = equivalency.wordPrefix('el/la');
+        const instance = new Equivalency().doesntMatter(beginsWithExcuseMe);
+
+        const inputs = [['el/la dentista', 'dentista']];
+
+        inputs.forEach(([s1, s2]) => {
+          expect(instance.equivalent(s1, s2)).toEqual(
+            expect.objectContaining({ isEquivalent: true })
+          );
+        });
+      });
     });
   });
 
@@ -1110,8 +1123,8 @@ describe('Real-world usage', () => {
       ]);
     });
   });
-  
-  describe('Punctuation As Whitespace Rule',() => {
+
+  describe('Punctuation As Whitespace Rule', () => {
     it('should return true when inputs differ by punctuation', () => {
       const instance = new Equivalency()
         .doesntMatter(Equivalency.es.PUNCTUATION_AS_WHITESPACE)
@@ -1119,7 +1132,7 @@ describe('Real-world usage', () => {
       const inputs = [
         ['No, tengo helado.', 'No, tengo helado.'], // exact match
         ['No, tengo helado.', 'No tengo helado'], // no punctuation
-        ['No, tengo helado.', 'No,tengo helado.'] // punctuation without spacing
+        ['No, tengo helado.', 'No,tengo helado.'], // punctuation without spacing
       ];
       inputs.forEach(([s1, s2]) => {
         expect(instance.equivalent(s1, s2)).toEqual(

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -8,7 +8,7 @@ const {
   isFunction,
   replaceAll,
   assert,
-  replaceAllCodepoints
+  replaceAllCodepoints,
 } = require('./helpers');
 const normalize = require('./normalize');
 
@@ -323,7 +323,13 @@ const combiningDiacriticsBlockExceptAcuteAndUmlautAndNTildeRule = new FunctionRu
 const wordPrefixRuleCreator = word =>
   new FunctionRule(
     (s1, s2) => {
-      const regexp = new RegExp(`^${word}\\s+`);
+      // some word prefixes can contains slashes which needs to be escaped
+      // before added to the regex.  Prettier and eslint are disabled here
+      // since they cannot tell the escape is not useless
+      // prettier-ignore
+      // eslint-disable-next-line no-useless-escape
+      const cleanedWord = word.replace('/', '\/');
+      const regexp = new RegExp(`^${cleanedWord}\\s+`);
       return [s1.replace(regexp, ''), s2.replace(regexp, '')];
     },
     { name: `wordPrefixRule '${word}'` }
@@ -384,5 +390,5 @@ module.exports = {
   HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES: hyphensOmittedOrReplacedWithSpaces(
     false
   ),
-  HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES_BOTH: hyphensOmittedOrReplacedWithSpaces()
+  HYPHENS_OMITTED_OR_REPLACED_WITH_SPACES_BOTH: hyphensOmittedOrReplacedWithSpaces(),
 };


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179454867

This change allows the word prefix rule generator to work with prefixes that contain a slash